### PR TITLE
COMP: Add missing <iostream> for ITKv6 build

### DIFF
--- a/Common/vtkComputeAirwayWall.cxx
+++ b/Common/vtkComputeAirwayWall.cxx
@@ -36,6 +36,8 @@
 #include "vtkPolyDataWriter.h"
 
 #include <math.h>
+#include <iostream>
+using namespace std;
 
 vtkStandardNewMacro(vtkComputeAirwayWall);
 

--- a/Common/vtkImageReformatAlongRay2.cxx
+++ b/Common/vtkImageReformatAlongRay2.cxx
@@ -24,6 +24,8 @@
 #include "teem/ell.h"
 
 #include <math.h>
+#include <iostream>
+using namespace std;
 
 vtkStandardNewMacro(vtkImageReformatAlongRay2);
 

--- a/Common/vtkSimpleLungMask.cxx
+++ b/Common/vtkSimpleLungMask.cxx
@@ -37,6 +37,8 @@
 #include <vtkInformation.h>
 #include <vtkStreamingDemandDrivenPipeline.h>
 #include <math.h>
+#include <iostream>
+using namespace std;
 
 vtkStandardNewMacro(vtkSimpleLungMask);
 

--- a/Utilities/VTK/vtkNRRDReaderCIP.cxx
+++ b/Utilities/VTK/vtkNRRDReaderCIP.cxx
@@ -50,6 +50,8 @@
 
 // Teem includes
 #include "teem/ten.h"
+#include <iostream>
+using namespace std;
 
 vtkStandardNewMacro(vtkNRRDReaderCIP);
 


### PR DESCRIPTION
ITKv6 no longer transitively includes `<iostream>`, so `vtkNRRDReaderCIP.cxx` fails to build with `error: use of undeclared identifier 'cout'`. This adds the explicit `<iostream>` include (and a `using namespace std;` to resolve the existing unqualified `cout`/`endl` usage).

<details>
<summary>Verification</summary>

`Utilities/VTK/vtkNRRDReaderCIP.cxx` — verified by replaying the failing compile command with `clang++ -fsyntax-only` against an ITKv6 (6.0) build; the TU now compiles. No behavioral change.
</details>

<!-- provenance: ITK forest-build testbed; found building Slicer's Chest_Imaging_Platform extension against a slicer-itk branch off latest upstream/main. -->
