### PR TITLE
COMP: Build against ITK 6

### DIFF
--- a/CommandLineTools/GenerateLobeSurfaceModels/GenerateLobeSurfaceModelsHelper.cxx
+++ b/CommandLineTools/GenerateLobeSurfaceModels/GenerateLobeSurfaceModelsHelper.cxx
@@ -1,4 +1,5 @@
 #include "GenerateLobeSurfaceModelsHelper.h"
+#include <vnl/algo/vnl_symmetric_eigensystem.h>
 
 void WriteTransformToFile( TransformType::Pointer transform, std::string fileName )
 {

--- a/Common/cipNewtonOptimizer.txx
+++ b/Common/cipNewtonOptimizer.txx
@@ -13,6 +13,7 @@
 #include "cipNewtonOptimizer.h"
 #include <vnl/algo/vnl_matrix_inverse.h>
 #include <vnl/algo/vnl_symmetric_eigensystem.h>
+#include <iostream>
 
 
 template < unsigned int Dimension >
@@ -97,7 +98,7 @@ void cipNewtonOptimizer< Dimension >::Update( bool verbose )
         std::abs(d[1])*outer_product(v.get_column(1),v.get_column(1));
       }
 
-    (*hInv) =  vnl_matrix_inverse<double>(h);    
+    (*hInv) =  vnl_matrix_inverse<double>(h).as_matrix();    
 
     (*p) = -(*hInv)*(*g); // Newton step    
     
@@ -123,7 +124,7 @@ void cipNewtonOptimizer< Dimension >::Update( bool verbose )
     if ( verbose )
       {
       std::cout << "Dimension:\t" << Dimension << std::endl;
-      std::cout << "this->GradientTolerance:\t" << this->GradientTolerance << std::endl;
+      std::cout << "this->GradientDifferenceTolerance:\t" << this->GradientDifferenceTolerance << std::endl;
       std::cout << "this->OptimalValue:\t" << this->OptimalValue << std::endl;
       std::cout << "Hessian:\t" << h[0][0] << "\t" << h[0][1] << "\t" << h[1][0] << "\t" << h[1][1] << "\t" << std::endl;
       std::cout << "Hessian Inv:\t" << (*hInv)[0][0] << "\t" << (*hInv)[0][1] << "\t" << (*hInv)[1][0] << "\t" << (*hInv)[1][1] << "\t" << std::endl;
@@ -187,7 +188,7 @@ void cipNewtonOptimizer< Dimension >::Update()
         std::abs(d[1])*outer_product(v.get_column(1),v.get_column(1));
       }
 
-    (*hInv) =  vnl_matrix_inverse<double>(h);    
+    (*hInv) =  vnl_matrix_inverse<double>(h).as_matrix();    
 
     (*p) = -(*hInv)*(*g); // Newton step    
     

--- a/Common/itkCIPMergeChestLabelMapsImageFilter.h
+++ b/Common/itkCIPMergeChestLabelMapsImageFilter.h
@@ -7,6 +7,7 @@
 #include "itkImageRegionIterator.h"
 #include "cipChestConventions.h"
 #include "cipHelper.h"
+#include <iostream>
 
 namespace itk
 {
@@ -55,7 +56,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(MergeChestLabelMapsImageFilter, ImageToImageFilter);
+  itkTypeMacro(CIPMergeChestLabelMapsImageFilter, ImageToImageFilter);
   
   /** Image typedef support. */
   typedef cip::LabelMapType::PixelType                        PixelType;

--- a/Common/vtkComputeAirwayWall.cxx
+++ b/Common/vtkComputeAirwayWall.cxx
@@ -36,6 +36,7 @@
 #include "vtkPolyDataWriter.h"
 
 #include <math.h>
+#include <iostream>
 
 vtkStandardNewMacro(vtkComputeAirwayWall);
 
@@ -454,7 +455,7 @@ int idx=0;
     loc2 = samples->GetValue(1);
 
     if (loc1>loc2 && loc2!= -1) {
-      cout<<"WARNING: Inner radius (loc1="<<loc1<<") is greater than outer radius (loc2="<<loc2<<")."<<endl;
+      std::cout<<"WARNING: Inner radius (loc1="<<loc1<<") is greater than outer radius (loc2="<<loc2<<")."<<std::endl;
       loc1=-1;
       loc2=-1;
     }
@@ -463,7 +464,7 @@ int idx=0;
     //  loc1 = radiusInner->GetValue(idx-1)/delta;
 
     //if (th ==0)
-    //  cout<<"Loc1: "<<loc1<<" "<<"Loc2: "<<loc2<<endl;
+    //  std::cout<<"Loc1: "<<loc1<<" "<<"Loc2: "<<loc2<<std::endl;
 
     //Take only into account good rays
     if (loc1 >0 && loc2 >0 ) {
@@ -762,7 +763,7 @@ int idx=0;
       lumenA->InsertNextValue(10000);
     }
     //Add points to final contour
-//    cout<<th<<" "<<loc1<<" "<<loc2<<endl;
+//    std::cout<<th<<" "<<loc1<<" "<<loc2<<std::endl;
      if (loc1 > 0) {
        radiusInner->InsertNextValue(loc1*delta);
        angleInner->InsertNextValue(th);
@@ -820,11 +821,11 @@ for (double th =-dth ; th <= 2*vtkMath::Pi(); th +=dth) {
 idx = 0;
 for (double th =0 ; th < 2*vtkMath::Pi(); th +=dth) {
   if (radiusInner->GetValue(idx) <=0) {
-    cout<<"Theta inner="<<th<<" Value="<<is->Evaluate(th)<<endl;
+    std::cout<<"Theta inner="<<th<<" Value="<<is->Evaluate(th)<<std::endl;
     radiusInner->SetValue(idx,is->Evaluate(th));
   }
   if (radiusOuter->GetValue(idx) <=0) {
-    cout<<"Th outer="<<th<<" Value="<<is->Evaluate(th)<<endl;
+    std::cout<<"Th outer="<<th<<" Value="<<is->Evaluate(th)<<std::endl;
     radiusOuter->SetValue(idx,os->Evaluate(th));
   }
   idx++;
@@ -1425,7 +1426,7 @@ void vtkComputeAirwayWall::RemoveOutliers(vtkDoubleArray *r) {
   e2r = e2r/tt;
 
   stdr = sqrt(e2r-meanr*meanr);
-  //cout<<"Robust mean = "<<meanr<<" Robust std = "<<stdr<<endl;
+  //std::cout<<"Robust mean = "<<meanr<<" Robust std = "<<stdr<<std::endl;
 
   //Set points to -1 that fall beyond the criteria
   for (int k=0; k<r->GetNumberOfTuples(); k++) {
@@ -1506,9 +1507,9 @@ meanLuminalI = (int) (meanLuminalI/lumenloc);
 if(this->WallThreshold <= meanLuminalI )
   {
   wallTh = this->WallThreshold + meanLuminalI;
-  //cout<<"Mean luminal I: "<<meanLuminalI<<endl;
-  //cout<<"Th floor: "<<this->WallThreshold<<endl;
-  //cout<<"Wall threhosld readjusted to: "<<wallTh<<endl;
+  //std::cout<<"Mean luminal I: "<<meanLuminalI<<std::endl;
+  //std::cout<<"Th floor: "<<this->WallThreshold<<std::endl;
+  //std::cout<<"Wall threhosld readjusted to: "<<wallTh<<std::endl;
   }
 else
   {
@@ -1525,7 +1526,7 @@ for (int k=0; k<nzeros; k++) {
   //Wall Candidate
   val = c->GetValue((int) loc);
   valg = cp->GetValue((int) loc);
-  //cout<<"Loc: "<<loc<<" Zero value: "<<val<<endl;
+  //std::cout<<"Loc: "<<loc<<" Zero value: "<<val<<std::endl;
   if (val>wallTh ) {
        //Wall center point (loc) has to be a maxima (cpp =< 0). We let inflection points pass.
         if (cpp->GetValue((int) loc) > 0) {
@@ -1560,10 +1561,10 @@ for (int k=0; k<nzeros; k++) {
     // Check that the inner wall location gradient is above the threshold.
     if (fabs(valg)<this->GradientThreshold)
 	    {
-	      //cout<<" Gradient= "<<fabs(valg)<<" at rmin="<<rmin<<endl;
+	      //std::cout<<" Gradient= "<<fabs(valg)<<" at rmin="<<rmin<<std::endl;
           continue;
 	    }
-            //cout<<"Find rmin: "<<rmin<<endl;
+            //std::cout<<"Find rmin: "<<rmin<<std::endl;
     }
 	//Check loc2 is in the allowed range
   if (int(loc2) >=ntuples || int(loc2) <0) {
@@ -1572,7 +1573,7 @@ for (int k=0; k<nzeros; k++) {
 	} else {
             val2 = c->GetValue((int) loc2);
             rmax=this->FindValue(c,(int) loc,(val+val2)/2);
-            //cout<<"Find rmax: "<<rmax<<endl;
+            //std::cout<<"Find rmax: "<<rmax<<std::endl;
 	}
     gzeros->Delete();
     //hzeros->Delete();
@@ -1970,7 +1971,7 @@ for (int i=0; i<numKernels-1; i++) {
          zc[0] = (-B + sqrt(res))/(2*A);
          zc[1] = (-B - sqrt(res))/(2*A);
        }
-       //cout<<"zc[0]: "<<zc[0]<<" zc[1]: "<<zc[1]<<endl;
+       //std::cout<<"zc[0]: "<<zc[0]<<" zc[1]: "<<zc[1]<<std::endl;
 
        for (int sol=0 ; sol<2; sol++) {
          if ((zc[sol]<(k+1) && zc[sol]>(k-1)) && (f1+f2)/2 > wallTh)
@@ -2096,7 +2097,7 @@ while (initIdx < np-1) {
 
    for (k =initIdx+1; k<np; k++) {
       val1 = c->GetValue(k);
-      //cout<<"k: "<<k<<" Val1: "<<val1<<endl;
+      //std::cout<<"k: "<<k<<" Val1: "<<val1<<std::endl;
       //Check for a change of sign
       if (val0*val1 <0) {
         val0 = c->GetValue(k-1);

--- a/Common/vtkComputeAirwayWallPolyData.cxx
+++ b/Common/vtkComputeAirwayWallPolyData.cxx
@@ -39,6 +39,7 @@
 #include "vtkImageThreshold.h"
 #include "vtkImageSeedConnectivity.h"
 #include "vtkComputeCentroid.h"
+#include <iostream>
 
 vtkStandardNewMacro(vtkComputeAirwayWallPolyData);
 
@@ -127,7 +128,7 @@ void vtkComputeAirwayWallPolyData::ExecuteInformation()
 
  if (this->GetOutput()->GetPointData()->GetScalars("Mean") != NULL)
  {
-   cout<<"Allocated"<<endl;
+   std::cout<<"Allocated"<<std::endl;
  }
  
  
@@ -244,8 +245,8 @@ int vtkComputeAirwayWallPolyData::RequestData(vtkInformation *request,
   
   output->DeepCopy(input);
   
-  //cout<<"Spacing: "<<sp[0]<<" "<<sp[1]<<" "<<sp[2]<<endl;
-  ///cout<<"Origin: "<<orig[0]<<" "<<orig[1]<<" "<<orig[2]<<endl;
+  //std::cout<<"Spacing: "<<sp[0]<<" "<<sp[1]<<" "<<sp[2]<<std::endl;
+  ///std::cout<<"Origin: "<<orig[0]<<" "<<orig[1]<<" "<<orig[2]<<std::endl;
   
   double resolution = this->Resolution;
 
@@ -289,7 +290,7 @@ int vtkComputeAirwayWallPolyData::RequestData(vtkInformation *request,
         this->SetAxisMode(VTK_HESSIAN);
        } else {
         reslicer->ComputeAxesOff();
-	cout<<"Using vectors"<<endl;
+	std::cout<<"Using vectors"<<std::endl;
        }
       break;
    }
@@ -401,7 +402,7 @@ int vtkComputeAirwayWallPolyData::RequestData(vtkInformation *request,
   for (vtkIdType k=0; k<npts; k++) {
   //for (vtkIdType k=400; k<403; k++) {
     input->GetPoints()->GetPoint(k,p);
-    cout<<"Processing point "<<k<<" out of "<<npts<<endl;
+    std::cout<<"Processing point "<<k<<" out of "<<npts<<std::endl;
     
    
   //reslicer->SetCenter(0.5+(p[0]+orig[0])/sp[0],511-((p[1]+orig[1])/sp[1])+0.5,(p[2]-orig[2])/sp[2]);
@@ -425,7 +426,7 @@ int vtkComputeAirwayWallPolyData::RequestData(vtkInformation *request,
        z[0]=this->AxisArray->GetComponent(k,0);
        z[1]=this->AxisArray->GetComponent(k,1);
        z[2]=this->AxisArray->GetComponent(k,2);
-       //cout<<"Tangent: "<<z[0]<<" "<<z[1]<<" "<<z[2]<<endl;
+       //std::cout<<"Tangent: "<<z[0]<<" "<<z[1]<<" "<<z[2]<<std::endl;
        vtkMath::Perpendiculars(z,x,y,0);
        reslicer->SetXAxis(x);
        reslicer->SetYAxis(y);
@@ -435,7 +436,7 @@ int vtkComputeAirwayWallPolyData::RequestData(vtkInformation *request,
        z[0]=input->GetPointData()->GetVectors()->GetComponent(k,0);
        z[1]=input->GetPointData()->GetVectors()->GetComponent(k,1);
        z[2]=input->GetPointData()->GetVectors()->GetComponent(k,2);
-       //cout<<"Tangent: "<<z[0]<<" "<<z[1]<<" "<<z[2]<<endl;
+       //std::cout<<"Tangent: "<<z[0]<<" "<<z[1]<<" "<<z[2]<<std::endl;
 
        vtkMath::Perpendiculars(z,x,y,0);
        reslicer->SetXAxis(x);
@@ -444,9 +445,9 @@ int vtkComputeAirwayWallPolyData::RequestData(vtkInformation *request,
        break;
    }
 
-   //cout<<"Before reslice"<<endl;
+   //std::cout<<"Before reslice"<<std::endl;
    reslicer->Update();
-   //cout<<"After reslice"<<endl;
+   //std::cout<<"After reslice"<<std::endl;
    
    vtkComputeAirwayWall *worker = this->WallSolver;
    worker->SetInputData(reslicer->GetOutput());
@@ -546,13 +547,13 @@ void vtkComputeAirwayWallPolyData::ComputeWallFromSolver(vtkComputeAirwayWall *w
     worker->SetMultiplicativeFactor(ml);
   }
   
-  //cout<<"Update solver"<<endl;
+  //std::cout<<"Update solver"<<std::endl;
   worker->Update();
-  //cout<<"Done solver"<<endl;
+  //std::cout<<"Done solver"<<std::endl;
   
   if (eifit != NULL)
   {
-    //cout<<"Ellipse fitting 1: "<<worker->GetInnerContour()->GetNumberOfPoints()<<endl;
+    //std::cout<<"Ellipse fitting 1: "<<worker->GetInnerContour()->GetNumberOfPoints()<<std::endl;
     if (worker->GetInnerContour()->GetNumberOfPoints() >= 3)
     {
       eifit->SetInputData(worker->GetInnerContour());
@@ -563,14 +564,14 @@ void vtkComputeAirwayWallPolyData::ComputeWallFromSolver(vtkComputeAirwayWall *w
   
   if (eofit !=NULL)
   {
-    //cout<<"Ellipse fitting 2: "<<worker->GetOuterContour()->GetNumberOfPoints()<<endl;
+    //std::cout<<"Ellipse fitting 2: "<<worker->GetOuterContour()->GetNumberOfPoints()<<std::endl;
     if (worker->GetOuterContour()->GetNumberOfPoints() >= 3)
     {
       eofit->SetInputData(worker->GetOuterContour());
       eofit->Update();
     }
   }
-  //cout<<"Done ellipse fitting"<<endl;
+  //std::cout<<"Done ellipse fitting"<<std::endl;
 
 }
 

--- a/Common/vtkExtractAirwayTree.cxx
+++ b/Common/vtkExtractAirwayTree.cxx
@@ -37,6 +37,7 @@
 
 #include "teem/nrrd.h"
 #include "teem/gage.h"
+#include <iostream>
 
 #define VTK_EPS 1e-12
 
@@ -193,7 +194,7 @@ int vtkExtractAirwayTree::RequestData(vtkInformation* vtkNotUsed(request),
     scaleAtSeed = 2;
   }
   double scale = scaleAtSeed;
-  cout<<"Tracking at Optimal scale: "<<scale<<endl;
+  std::cout<<"Tracking at Optimal scale: "<<scale<<std::endl;
 
   // Setting up the context and the state according to the estimated scaled.
   if (this->SettingContextAndState(gtx,pvl,state,scaleAtSeed)) {
@@ -215,7 +216,7 @@ int vtkExtractAirwayTree::RequestData(vtkInformation* vtkNotUsed(request),
   newS[2]=this->Seed[2];
   this->RelocateSeed(gtx,pvl,newS,newS);
   scale = this->ScaleSelection(gtx,pvl,newS,2.0,10.0,0.1);
-  cout<<"New scale: "<<scale<<endl;
+  std::cout<<"New scale: "<<scale<<std::endl;
   kparm[0] = floor(scale);
   if (!E) E |= gageKernelSet(gtx, gageKernel00, nrrdKernelBCCubic, kparm);
   if (!E) E |= gageKernelSet(gtx, gageKernel11, nrrdKernelBCCubicD, kparm);
@@ -269,7 +270,7 @@ int vtkExtractAirwayTree::RequestData(vtkInformation* vtkNotUsed(request),
       //3. ApplyUpdate
       //4. Apply Constrain: seed should be in a minimum
 
-      //cout<<"NEW STEP: Direction "<<direction[forward]<<"  ----"<<endl;
+      //std::cout<<"NEW STEP: Direction "<<direction[forward]<<"  ----"<<std::endl;
       // Probing should be always done like this:
       state->Update(newS); //Save state at k-1, probe at k and compute direction of evolution
 
@@ -284,7 +285,7 @@ int vtkExtractAirwayTree::RequestData(vtkInformation* vtkNotUsed(request),
             // No good scale was found. Let us break here
             break;
           }
-          cout<<"Stop Condition Optimal scale: "<<scale<<endl;
+          std::cout<<"Stop Condition Optimal scale: "<<scale<<std::endl;
           if (this->SettingContextAndState(gtx,pvl,state,scale)) 
             {
             vtkErrorMacro("Error Setting Gage Context... Leaving Execute");
@@ -300,13 +301,13 @@ int vtkExtractAirwayTree::RequestData(vtkInformation* vtkNotUsed(request),
           // If condition is stop, break, if not, keep moving.
           if (this->StoppingCondition(state) == STOP)
             {
-            //cout<<"Bailing out..."<<endl;
+            //std::cout<<"Bailing out..."<<std::endl;
             break;
             }
           }
         else 
           {
-          //cout<<"Bailing out..."<<endl;
+          //std::cout<<"Bailing out..."<<std::endl;
           break;
           }
         }
@@ -315,13 +316,13 @@ int vtkExtractAirwayTree::RequestData(vtkInformation* vtkNotUsed(request),
                               state->Seed[2]);
 
       // Apply new Update
-      cout<<"Seed in state (before step): "<<state->Seed[0]<<" "<<state->Seed[1]<<" "<<state->Seed[2]<<endl;
+      std::cout<<"Seed in state (before step): "<<state->Seed[0]<<" "<<state->Seed[1]<<" "<<state->Seed[2]<<std::endl;
       this->ApplyUpdate(state,newS);
-      cout<<"Seed after taking step: "<<newS[0]<<" "<<newS[1]<<" "<<newS[2]<<endl;
-      cout<<"State direction: "<<state->direction<<endl;
+      std::cout<<"Seed after taking step: "<<newS[0]<<" "<<newS[1]<<" "<<newS[2]<<std::endl;
+      std::cout<<"State direction: "<<state->direction<<std::endl;
       //Move the seed to the minimum in the d Dim -plane
       this->RelocateSeed(gtx,pvl,newS,newS);
-      cout<<"Seed after relocation: "<<newS[0]<<" "<<newS[1]<<" "<<newS[2]<<endl;
+      std::cout<<"Seed after relocation: "<<newS[0]<<" "<<newS[1]<<" "<<newS[2]<<std::endl;
 
       numIter++;
     }while(numIter < 2*ITERMAX);
@@ -339,8 +340,8 @@ int vtkExtractAirwayTree::RequestData(vtkInformation* vtkNotUsed(request),
   //NrrdIoState *nio = nrrdIoStateNew();
   //nrrdSave("test.nrrd",nin,nio); 
   //nrrdNix(nin);
-  cout<<"Num points backwards: "<<npts[1]<<endl;
-  cout<<"Num points forward: "<<npts[2]-npts[1]<<endl;
+  std::cout<<"Num points backwards: "<<npts[1]<<std::endl;
+  std::cout<<"Num points forward: "<<npts[2]-npts[1]<<std::endl;
   vtkDebugMacro(<<"Created: " 
                << newPts->GetNumberOfPoints() << " points, " 
                << newPolys->GetNumberOfCells() << " lines");
@@ -444,7 +445,7 @@ int vtkExtractAirwayTree::StoppingCondition(vtkTrackingState *state)
   input->GetDimensions(dims);
   for (int k=0; k<3; k++) {
     if (state->Seed[k] >=dims[k] || state->Seed[k]<0) {
-      cout<<"Point is a out-of-bounds"<<endl;
+      std::cout<<"Point is a out-of-bounds"<<std::endl;
       return STOP;
     }
   } 
@@ -461,36 +462,36 @@ int vtkExtractAirwayTree::StoppingCondition(vtkTrackingState *state)
                     pow((grad[0]*hevec[6]+grad[1]*hevec[7]+grad[2]*hevec[8]),2));
   }
 
-    cout<<"Stopping criteria: 1. Orth: "<<orth<<"   2. Mode: "<<mode<<"  heval[1]: "<<heval[1]<<endl;
+    std::cout<<"Stopping criteria: 1. Orth: "<<orth<<"   2. Mode: "<<mode<<"  heval[1]: "<<heval[1]<<std::endl;
       
   // Conditions for being a generalized minimum
   if (featureSign*heval[1] < 0) {
-    cout<<"Not a valley"<<endl;
+    std::cout<<"Not a valley"<<std::endl;
     return STOP;
    }
 
   if (orth > 0.05) {
-    cout<<"Gradient not orthogonal to tube frame"<<endl;
+    std::cout<<"Gradient not orthogonal to tube frame"<<std::endl;
     return STOP;
     }
 
    // Conditions for being a strong valley
    if (featureSign*heval[1] < fabs(heval[2])) {
-     cout <<"Weak valley:"<<endl;
+     std::cout <<"Weak valley:"<<std::endl;
      return STOP;
    }
 
   // I THINK THAT FOR "STRENGTH" OF A RIDGE LINE
   // WE SHOULD TEST FOR:
   //if (featureSign*heval[1] < fabs(heval[0])) {
-  //    cout <<"Weak valley:"<<endl;
+  //    std::cout <<"Weak valley:"<<std::endl;
   //    return STOP;
   //  }
 
 
       
    //if (mode >= 0) {
-   //  cout<<"Mode change sign: potential branch"<<endl;
+   //  std::cout<<"Mode change sign: potential branch"<<std::endl;
    //  return STOP;
    // }
 
@@ -498,7 +499,7 @@ int vtkExtractAirwayTree::StoppingCondition(vtkTrackingState *state)
   // Mode can be positive and this could mean that this is a
   // weak tube, for example for large airway (bronchus)
   //  if (-1.0*featureSign*mode< this->ModeThreshold) {
-  //    cout<<"Potenial branch"<<endl; 
+  //    std::cout<<"Potenial branch"<<std::endl; 
   //    return STOP;
   //   }
 
@@ -515,25 +516,25 @@ void vtkExtractAirwayTree::PrintState(vtkTrackingState *state)
   const double *grad = state->grad;
   double *newS = state->Seed;
   double mode= this->Mode(heval);
-      cout<<"Probing Seed: "<<newS[0]<<" "<<newS[1]<<" "<<newS[2]<<endl; 
-      cout<<"Hessian eval: "<<heval[0]<<" "<<heval[1]<<" "<<heval[2]<<endl;
-      cout<<"Hessian ev1: "<<hevec[0]<<" "<<hevec[1]<<" "<<hevec[2]<<endl;
-      cout<<"Hessian ev2: "<<hevec[3]<<" "<<hevec[4]<<" "<<hevec[5]<<endl;
-      cout<<"Hessian ev3: "<<hevec[6]<<" "<<hevec[7]<<" "<<hevec[8]<<endl;
-      cout<<"Gradient: "<<grad[0]<<" "<<grad[1]<<" "<<grad[2]<<endl;
-      cout<<"Mode: "<<mode<<endl;
-      cout<<"Direction: "<<state->direction<<endl;
+      std::cout<<"Probing Seed: "<<newS[0]<<" "<<newS[1]<<" "<<newS[2]<<std::endl; 
+      std::cout<<"Hessian eval: "<<heval[0]<<" "<<heval[1]<<" "<<heval[2]<<std::endl;
+      std::cout<<"Hessian ev1: "<<hevec[0]<<" "<<hevec[1]<<" "<<hevec[2]<<std::endl;
+      std::cout<<"Hessian ev2: "<<hevec[3]<<" "<<hevec[4]<<" "<<hevec[5]<<std::endl;
+      std::cout<<"Hessian ev3: "<<hevec[6]<<" "<<hevec[7]<<" "<<hevec[8]<<std::endl;
+      std::cout<<"Gradient: "<<grad[0]<<" "<<grad[1]<<" "<<grad[2]<<std::endl;
+      std::cout<<"Mode: "<<mode<<std::endl;
+      std::cout<<"Direction: "<<state->direction<<std::endl;
 
-      cout<<"Tangent: "<<state->Seed[0]-state->PSeed[0]<<" "<<state->Seed[1]-state->PSeed[1]<<" "<<state->Seed[2]-state->PSeed[2]<<endl;
-      cout<<"Step: "<<state->hevec[6]<<" "<<state->hevec[7]<<" "<<state->hevec[8]<<endl;
-      cout<<"Inner product: "<<(state->Seed[0]-state->PSeed[0])*state->hevec[6] + 
+      std::cout<<"Tangent: "<<state->Seed[0]-state->PSeed[0]<<" "<<state->Seed[1]-state->PSeed[1]<<" "<<state->Seed[2]-state->PSeed[2]<<std::endl;
+      std::cout<<"Step: "<<state->hevec[6]<<" "<<state->hevec[7]<<" "<<state->hevec[8]<<std::endl;
+      std::cout<<"Inner product: "<<(state->Seed[0]-state->PSeed[0])*state->hevec[6] + 
                      (state->Seed[1]-state->PSeed[1])*state->hevec[7] +
-                     (state->Seed[2]-state->PSeed[2])*state->hevec[8]<<endl;
+                     (state->Seed[2]-state->PSeed[2])*state->hevec[8]<<std::endl;
 }
 
 int vtkExtractAirwayTree::RelocateSeed(gageContext *gtx, gagePerVolume *pvl, double Seed[3], double SeedNew[3])
 {
-//cout<<"RelocateSeed"<<endl;
+//std::cout<<"RelocateSeed"<<std::endl;
   double m[9], m2[9];
   double gradp[3];
   double lgrad;
@@ -611,7 +612,7 @@ int vtkExtractAirwayTree::RelocateSeed(gageContext *gtx, gagePerVolume *pvl, dou
     xn[0] = x[0]-step*gradp[0];
     xn[1] = x[1]-step*gradp[1];
     xn[2] = x[2]-step*gradp[2];
-    //cout<<"New Point: "<<x[0]<<" "<<x[1]<<" "<<x[2]<<endl;
+    //std::cout<<"New Point: "<<x[0]<<" "<<x[1]<<" "<<x[2]<<std::endl;
     gageProbe(gtx,xn[0],xn[1],xn[2]);
     if ((featureSign*prevv - featureSign*(double) valu[0]) < 0) 
      {
@@ -653,7 +654,7 @@ return converge;
 int vtkExtractAirwayTree::RelocateSeedInPlane(gageContext *gtx, gagePerVolume *pvl, double Seed[3], double SeedNew[3],int axis)
 {
 
-//cout<<"Relocate Seed In Plane"<<endl;
+//std::cout<<"Relocate Seed In Plane"<<std::endl;
   double m[9];
   double gradp[3];
   double lgrad;
@@ -691,7 +692,7 @@ int vtkExtractAirwayTree::RelocateSeedInPlane(gageContext *gtx, gagePerVolume *p
   double x[3],xn[3];
   double normal[3];
   x[0]=Seed[0];x[1]=Seed[1];x[2]=Seed[2];
-  //cout<<"Init Poinit: "<<x[0]<<" "<<x[1]<<" "<<x[2]<<endl;
+  //std::cout<<"Init Poinit: "<<x[0]<<" "<<x[1]<<" "<<x[2]<<std::endl;
   gageProbe(gtx,x[0],x[1],x[2]);
 
   normal[0] = 0.0;
@@ -734,13 +735,13 @@ int vtkExtractAirwayTree::RelocateSeedInPlane(gageContext *gtx, gagePerVolume *p
     xn[0] = x[0]-step*gradp[0];
     xn[1] = x[1]-step*gradp[1];
     xn[2] = x[2]-step*gradp[2];
-    //cout<<"GRad p: "<<gradp[0]<<" "<<gradp[1]<<" "<<gradp[2]<<" lgrad: "<<lgrad<<endl;
-    //cout<<"Delta: "<<delta<<"  New Point: "<<xn[0]<<" "<<xn[1]<<" "<<xn[2]<<"  Value: "<<valu[0]<<endl;
+    //std::cout<<"GRad p: "<<gradp[0]<<" "<<gradp[1]<<" "<<gradp[2]<<" lgrad: "<<lgrad<<std::endl;
+    //std::cout<<"Delta: "<<delta<<"  New Point: "<<xn[0]<<" "<<xn[1]<<" "<<xn[2]<<"  Value: "<<valu[0]<<std::endl;
     gageProbe(gtx,xn[0],xn[1],xn[2]);
     if ((featureSign*prevv - featureSign*(double) valu[0]) < 0) {
       hack = hack/2;
       numIter++;
-      //cout<<"Step update: "<<step<<endl;
+      //std::cout<<"Step update: "<<step<<std::endl;
       continue;
     }
     if (fabs(featureSign*prevv - featureSign*(double) valu[0]) < 0.001 || fabs(step)<0.0001) {
@@ -826,7 +827,7 @@ double vtkExtractAirwayTree::ScaleSelection(gageContext *gtx, gagePerVolume *pvl
     //heval = gageAnswerPointer(gtx, pvl, gageSclHessEval);
     gageProbe(gtx,Seed[0],Seed[1],Seed[2]);
 
-    //cout<<"Testing Scale: "<<S<<"  Eigenvalues: "<<heval[0]<<" "<<heval[1]<<" "<<heval[2]<<"  Mode: "<<this->Mode(heval)<<"  Disparity measure: "<< (heval[0] + heval[1])/2 - fabs(heval[2])<<endl;
+    //std::cout<<"Testing Scale: "<<S<<"  Eigenvalues: "<<heval[0]<<" "<<heval[1]<<" "<<heval[2]<<"  Mode: "<<this->Mode(heval)<<"  Disparity measure: "<< (heval[0] + heval[1])/2 - fabs(heval[2])<<std::endl;
     
     //Normalized strenght: multiply for scale square
     nextV = S*S*featureSign*this->Strength(heval);
@@ -841,13 +842,13 @@ double vtkExtractAirwayTree::ScaleSelection(gageContext *gtx, gagePerVolume *pvl
     } else {
         strength[idx]=0;
     }
-   //cout<<"Scale: "<<S<<" Mode: "<<nextV<<" h[0]: "<<heval[0]<<" h[1]: "<<heval[1]<<" h[2]: "<<heval[2]<<endl;
+   //std::cout<<"Scale: "<<S<<" Mode: "<<nextV<<" h[0]: "<<heval[0]<<" h[1]: "<<heval[1]<<" h[2]: "<<heval[2]<<std::endl;
 
 
     S = S+deltaS;
      idx++;
      } while( S <= maxS);
-   //cout<<"Sopt: "<<Sopt<<"  prevV: "<<prevV<<endl;
+   //std::cout<<"Sopt: "<<Sopt<<"  prevV: "<<prevV<<std::endl;
 
     S = initS;
     idx = 0;
@@ -861,7 +862,7 @@ double vtkExtractAirwayTree::ScaleSelection(gageContext *gtx, gagePerVolume *pvl
       S = S + deltaS;
       idx++;
     } while (S<=Sopt);
-    //cout<<"Sopt2: "<<Sopt2<<endl;
+    //std::cout<<"Sopt2: "<<Sopt2<<std::endl;
     // If maximun strength was positive, use Sopt2.
     if (prevV > 0)
       Sopt = Sopt2;

--- a/Common/vtkImageKernelSource.cxx
+++ b/Common/vtkImageKernelSource.cxx
@@ -7,6 +7,7 @@
 #include "vtkInformation.h"
 #include "vtkInformationVector.h"
 #include "vtkStreamingDemandDrivenPipeline.h"
+#include <iostream>
 
 #define VTK_NUM_DIMENSIONS 3
 
@@ -426,7 +427,7 @@ void vtkImageKernelSource::ThreadedFourierCenterExecute(vtkImageData *inData,
         this->ComputeInputIndex(outIndx,mid,inIndx);
         inPtr = (double *) inData->GetScalarPointer(inIndx[0],inIndx[1],inIndx[2]);
         if (inPtr == NULL) {
-          cout<<"Error in fftshift: index out out boundaries"<<endl;
+          std::cout<<"Error in fftshift: index out out boundaries"<<std::endl;
           continue;
         }
 

--- a/Common/vtkImageReformatAlongRay.cxx
+++ b/Common/vtkImageReformatAlongRay.cxx
@@ -24,6 +24,7 @@
 #include "teem/ell.h"
 
 #include <math.h>
+#include <iostream>
 
 vtkStandardNewMacro(vtkImageReformatAlongRay);
 
@@ -146,7 +147,7 @@ void vtkImageReformatAlongRay::ExecuteDataWithInformation(vtkDataObject *out,
   vtkImageData *output = this->GetOutput();
   output->AllocateScalars(outInfo);
   //vtkIndent ident;
-  //output->PrintSelf(cout,ident);
+  //output->PrintSelf(std::cout,ident);
 
   // Convert input to nrrd
   int dims[3];
@@ -173,7 +174,7 @@ void vtkImageReformatAlongRay::ExecuteDataWithInformation(vtkDataObject *out,
   }
 
   if(nrrdWrap_nva(this->nin,data,type,3,size)) {
-	cout<<"Error with nrrdWrap"<<endl;
+	std::cout<<"Error with nrrdWrap"<<std::endl;
         //sprintf(err,"%s:",me);
 	//biffAdd(NRRD, err); return;
   }
@@ -212,8 +213,8 @@ void vtkImageReformatAlongRay::ExecuteDataWithInformation(vtkDataObject *out,
   //Loop through ray points
   double dp[3],vp[3],xp[3];
   // Delta increment in the point
-  //cout<<"Theta: "<<this->Theta;
-  //cout<<"Center: "<<this->Center[0]<<" "<<this->Center[1]<<" "<<this->Center[2]<<endl;
+  //std::cout<<"Theta: "<<this->Theta;
+  //std::cout<<"Center: "<<this->Center[0]<<" "<<this->Center[1]<<" "<<this->Center[2]<<std::endl;
   vp[0] =  cos(this->Theta);
   vp[1] =  sin(this->Theta);
   vp[2] = 0;

--- a/Common/vtkImageReformatAlongRay2.cxx
+++ b/Common/vtkImageReformatAlongRay2.cxx
@@ -24,6 +24,7 @@
 #include "teem/ell.h"
 
 #include <math.h>
+#include <iostream>
 
 vtkStandardNewMacro(vtkImageReformatAlongRay2);
 
@@ -114,7 +115,7 @@ void vtkImageReformatAlongRay2::ExecuteDataWithInformation(vtkDataObject *out,
   vtkImageData *output = this->GetOutput();
   output->AllocateScalars(outInfo);
   //vtkIndent ident;
-  //output->PrintSelf(cout,ident);
+  //output->PrintSelf(std::cout,ident);
 
   // Convert input to nrrd
   int dims[3];
@@ -141,7 +142,7 @@ void vtkImageReformatAlongRay2::ExecuteDataWithInformation(vtkDataObject *out,
   }
  
   if(nrrdWrap_nva(this->nin,data,type,3,size)) {
-	cout<<"Error with nrrdWrap"<<endl;
+	std::cout<<"Error with nrrdWrap"<<std::endl;
         //sprintf(err,"%s:",me);
 	//biffAdd(NRRD, err); return;
   }

--- a/Common/vtkImageTubularConfidence.cxx
+++ b/Common/vtkImageTubularConfidence.cxx
@@ -39,6 +39,7 @@
 #include "vtkTubularScaleSelection.h"
 #include "vtkExtractAirwayTree.h"
 #include "vtkMath.h"
+#include <iostream>
 
 vtkStandardNewMacro(vtkImageTubularConfidence);
 
@@ -227,7 +228,7 @@ void vtkImageTubularConfidenceExecute(vtkImageTubularConfidence *self, vtkImageD
         if (!(count%target))
           {
           self->UpdateProgress(count/(50.0*target));
-          cout<<"Progress Update: "<<count/(50.0*target)<<endl;
+          std::cout<<"Progress Update: "<<count/(50.0*target)<<std::endl;
           }
         count++;
         }

--- a/Common/vtkLungIntensityCorrection.cxx
+++ b/Common/vtkLungIntensityCorrection.cxx
@@ -23,6 +23,7 @@
 #include "vtkExecutive.h"
 
 #include <math.h>
+#include <iostream>
 
 vtkStandardNewMacro(vtkLungIntensityCorrection);
 
@@ -213,7 +214,7 @@ void vtkLungIntensityCorrectionExecute(vtkLungIntensityCorrection *self,
   for (idZ = outExt[4]; idZ <= outExt[5]; idZ++)
     {
     idx = 0;
-    cout<<"Slice "<<idZ<<endl;
+    std::cout<<"Slice "<<idZ<<std::endl;
     for (idY = outExt[2]; idY <= outExt[3]; idY++)
       {
       if (!id) 
@@ -289,7 +290,7 @@ void vtkLungIntensityCorrectionExecute(vtkLungIntensityCorrection *self,
         if (nvalue > 0)
           {
            value = value/nvalue;
-           //cout <<"Value: "<<value<<endl;
+           //std::cout <<"Value: "<<value<<std::endl;
 
            //Fill matrices to solve LS problem
            xt[idx][0] = idY;
@@ -350,8 +351,8 @@ void vtkLungIntensityCorrectionExecute(vtkLungIntensityCorrection *self,
            dcvalue = (m*minY+n);
          break;
       }
-    cout<<"parameters (m,n): "<<m<<" "<<n<<endl;  
-    cout<<"dcvalue: "<<dcvalue<<" minY: "<<minY<<" maxY:"<<maxY<<endl;
+    std::cout<<"parameters (m,n): "<<m<<" "<<n<<std::endl;  
+    std::cout<<"dcvalue: "<<dcvalue<<" minY: "<<minY<<" maxY:"<<maxY<<std::endl;
 
     for (idY = outExt[2]; idY <= outExt[3]; idY++)
       {

--- a/Common/vtkMaskBoundingBox.cxx
+++ b/Common/vtkMaskBoundingBox.cxx
@@ -3,6 +3,7 @@
 #include <vtkObjectFactory.h>
 #include <vtkImageToImageStencil.h>
 #include "vtkImageData.h"
+#include <iostream>
 
 vtkStandardNewMacro(vtkMaskBoundingBox);
 
@@ -78,7 +79,7 @@ void vtkMaskBoundingBox::Compute()
     this->BoundingBox[2*i+1]=VTK_INT_MIN;
     } 
   
-  cout<<"Starting looping..."<<endl;
+  std::cout<<"Starting looping..."<<std::endl;
   for (zidx = ext[4]; zidx <= ext[5]; zidx++)
     {
     for (yidx = ext[2]; yidx <= ext[3]; yidx++)
@@ -93,7 +94,7 @@ void vtkMaskBoundingBox::Compute()
 	        }
         else
           {  
-	          //cout<<"r1: "<<r1<<"  r2: "<<r2<<" iter: "<<iter<<endl;
+	          //std::cout<<"r1: "<<r1<<"  r2: "<<r2<<" iter: "<<iter<<std::endl;
 	    
     	    if (r1<this->BoundingBox[0])
     	       this->BoundingBox[0]=r1;
@@ -116,7 +117,7 @@ void vtkMaskBoundingBox::Compute()
       
    for (int i =0 ;i<6;i++)
      {
-     cout<<"BB "<<i<<": "<<this->BoundingBox[i]<<endl;
+     std::cout<<"BB "<<i<<": "<<this->BoundingBox[i]<<std::endl;
      }
  }
 

--- a/Common/vtkSimpleLungMask.cxx
+++ b/Common/vtkSimpleLungMask.cxx
@@ -37,6 +37,7 @@
 #include <vtkInformation.h>
 #include <vtkStreamingDemandDrivenPipeline.h>
 #include <math.h>
+#include <iostream>
 
 vtkStandardNewMacro(vtkSimpleLungMask);
 
@@ -147,8 +148,8 @@ void vtkSimpleLungMask::ComputeCentroids(vtkImageData *in, int LC[3], int RC[3])
         extR[axis*2] = (int) (ext[axis*2 + 1]/2 + 0.5);
         extL[axis*2+1] = extR[axis*2]-1;
     }
-    cout<<"Extent left: "<<extL[0]<<"-"<<extL[1]<<" "<<extL[2]<<"-"<<extL[3]<<" "<<extL[4]<<"-"<<extL[5]<<endl;
-    cout<<"Extent right: "<<extR[0]<<"-"<<extR[1]<<" "<<extR[2]<<"-"<<extL[3]<<" "<<extR[4]<<"-"<<extR[5]<<endl;
+    std::cout<<"Extent left: "<<extL[0]<<"-"<<extL[1]<<" "<<extL[2]<<"-"<<extL[3]<<" "<<extL[4]<<"-"<<extL[5]<<std::endl;
+    std::cout<<"Extent right: "<<extR[0]<<"-"<<extR[1]<<" "<<extR[2]<<"-"<<extL[3]<<" "<<extR[4]<<"-"<<extR[5]<<std::endl;
 
     //Before computing centroids:
     this->ComputeCentroid(in,extL,LC);
@@ -214,7 +215,7 @@ vtkImageData *vtkSimpleLungMask::PreVolumeProcessing(vtkImageData *in, int &ZCen
     th->SetInput(in);
     th->SetInsideValue(1);
     th->SetOutsideValue(0);
-    cout<<"Updating Otsu"<<endl;
+    std::cout<<"Updating Otsu"<<std::endl;
     th->Update();
     this->LungThreshold = th->GetThreshold();
     */
@@ -266,10 +267,10 @@ vtkImageData *vtkSimpleLungMask::PreVolumeProcessing(vtkImageData *in, int &ZCen
     bgrm->Delete();
 
     //Compute centroid
-    cout<<"Compute centroids"<<endl;
+    std::cout<<"Compute centroids"<<std::endl;
     this->ComputeCentroids(th->GetOutput(), this->LCentroid, this->RCentroid);
-    cout<<"CentroidL: "<<LCentroid[0]<<" "<<LCentroid[1]<<" "<<LCentroid[2]<<endl;
-    cout<<"CentroidR: "<<RCentroid[0]<<" "<<RCentroid[1]<<" "<<RCentroid[2]<<endl;
+    std::cout<<"CentroidL: "<<LCentroid[0]<<" "<<LCentroid[1]<<" "<<LCentroid[2]<<std::endl;
+    std::cout<<"CentroidR: "<<RCentroid[0]<<" "<<RCentroid[1]<<" "<<RCentroid[2]<<std::endl;
 
     // Make sure we get only the components connected to the centroid
     // Here we should have a decent lung mask
@@ -281,7 +282,7 @@ vtkImageData *vtkSimpleLungMask::PreVolumeProcessing(vtkImageData *in, int &ZCen
     connect->SetOutputUnconnectedValue(0);
     connect->AddSeed(this->LCentroid[0],this->LCentroid[1],this->LCentroid[2]);
     connect->AddSeed(this->RCentroid[0],this->RCentroid[1],this->RCentroid[2]);
-    cout<<"CC"<<endl;
+    std::cout<<"CC"<<std::endl;
 
     connect->Update();
 
@@ -372,7 +373,7 @@ int vtkSimpleLungMask::SliceProcessing(vtkImageData *in,vtkImageData *out, int z
   int LC[3];
   int RC[3];
   this->ComputeCentroids(in, LC, RC);
-  //cout<<"Centroid Slice processing: "<<LC[0]<<" "<<LC[1]<<" "<<RC[0]<<" "<<RC[1]<<endl;
+  //std::cout<<"Centroid Slice processing: "<<LC[0]<<" "<<LC[1]<<" "<<RC[0]<<" "<<RC[1]<<std::endl;
   if ((LC[0] ==0 && LC[1] ==0) &&
         (RC[0]==0 && RC[1]==0))
         return 0;
@@ -541,11 +542,11 @@ void vtkSimpleLungMask::ExecuteDataWithInformation(vtkDataObject *output, vtkInf
   vtkImageData *sliceMask = NULL; //Mask for slice processing 2D
   int ZCentroid;
 
-  //cout<<"Before prevolume processing"<<endl;
+  //std::cout<<"Before prevolume processing"<<std::endl;
   this->UpdateProgress(0.1);
   preMask = this->PreVolumeProcessing(inData,ZCentroid);
   this->UpdateProgress(0.4);
-  //cout<<"Done prevolume"<<endl;
+  //std::cout<<"Done prevolume"<<std::endl;
 
   /*******************************
   int ext[6];
@@ -607,15 +608,15 @@ void vtkSimpleLungMask::ExecuteDataWithInformation(vtkDataObject *output, vtkInf
   sliceMask->Delete();
 
   // Post volume processing
-  //cout<<"Post volume processing ..."<<endl;
+  //std::cout<<"Post volume processing ..."<<std::endl;
   //this->PostVolumeProcessing(preMask,outData);
-  //cout<<"postvolume DONE"<<endl;
+  //std::cout<<"postvolume DONE"<<std::endl;
   //Here final result should be in outData;
   *************************************************/
 
   // Extract trachea. Based on preMask analysis, relabel output.
-  //cout<<"Extracting Trachea"<<endl;
-  cout<<"Extracting Trachea"<<endl;
+  //std::cout<<"Extracting Trachea"<<std::endl;
+  std::cout<<"Extracting Trachea"<<std::endl;
   this->ExtractTrachea(preMask);
   this->UpdateProgress(0.5);
 
@@ -648,14 +649,14 @@ void vtkSimpleLungMask::ExecuteDataWithInformation(vtkDataObject *output, vtkInf
   con->SetFunctionToRemoveIslands();
   con->SetMinSize(1000);
   con->SliceBySliceOn();
-  cout<<"Removing Island"<<endl;
+  std::cout<<"Removing Island"<<std::endl;
   con->Update();
 
   this->UpdateProgress(0.6);
 
   //Clean potential crap from Image Connectivity
   short *conPtr = (short *) con->GetOutput()->GetScalarPointer();
-  cout<<"Cleaning Remove Islands"<<endl;
+  std::cout<<"Cleaning Remove Islands"<<std::endl;
   outPtr = (short *) outData->GetScalarPointer();
   for (int i=0; i<outData->GetNumberOfPoints();i++) {
     if (*conPtr == this->WholeLungLabel || *conPtr == this->TracheaLabel)
@@ -756,7 +757,7 @@ void vtkSimpleLungMask::ExecuteDataWithInformation(vtkDataObject *output, vtkInf
   air->Delete();
 
   // Slip the lung in three regions
-  cout<<"Split Lung in regions"<<endl;
+  std::cout<<"Split Lung in regions"<<std::endl;
   this->SplitLung(outData);
   this->UpdateProgress(0.95);
 
@@ -846,23 +847,23 @@ void vtkSimpleLungMask::FindTracheaTopCoordinates(vtkImageData *in,int initZ, in
   do {
       testext[4]=k;
       testext[5]=k;
-      //cout<<"Ready to copy buffer to slice "<<k<<endl;
+      //std::cout<<"Ready to copy buffer to slice "<<k<<std::endl;
       this->CopyToBuffer(in,slice1,testext);
       testext[4]=0;
       testext[5]=0;
       slice1->SetExtent(testext);
       conk->SetInputData(slice1);
-      //cout<<"Updating Identify island"<<endl;
+      //std::cout<<"Updating Identify island"<<std::endl;
       conk->Update();
       testext[4]=k+sign;
       testext[5]=k+sign;
-      //cout<<"Ready to copy buffer to slice "<<k+sign<<endl;
+      //std::cout<<"Ready to copy buffer to slice "<<k+sign<<std::endl;
       this->CopyToBuffer(in,slice2,testext);
       testext[4]=0;
       testext[5]=0;
       slice2->SetExtent(testext);
       conkp1->SetInputData(slice2);
-      //cout<<"Updating Identify island"<<endl;
+      //std::cout<<"Updating Identify island"<<std::endl;
       conkp1->Update();
 
       //Loop through each CC in slice k
@@ -877,11 +878,11 @@ void vtkSimpleLungMask::FindTracheaTopCoordinates(vtkImageData *in,int initZ, in
       }
       */
       this->Histogram(conk->GetOutput(),hist,0,499);
-      cout<<"Histogram= ";
+      std::cout<<"Histogram= ";
       for (int i=0;i<20;i++) {
-	cout<<hist[i]<<" ";
+	std::cout<<hist[i]<<" ";
       }
-      cout<<endl;
+      std::cout<<std::endl;
 
       for (short cc=1;cc<500;cc++) {
 	int countk=hist[cc];
@@ -889,12 +890,12 @@ void vtkSimpleLungMask::FindTracheaTopCoordinates(vtkImageData *in,int initZ, in
 	  continue;
 	}
         if (countk*sp[0]*sp[1] > this->TracheaAreaTh) {
-	  cout<<"cc ="<<cc<<" Too big to be the trachea countk "<<countk<<endl;
+	  std::cout<<"cc ="<<cc<<" Too big to be the trachea countk "<<countk<<std::endl;
           continue;
 	}
 
 	if (countk < 10) {
-	  cout <<"cc="<<cc<<" Too small "<<countk<<endl;
+	  std::cout <<"cc="<<cc<<" Too small "<<countk<<std::endl;
 	}
 
         th->SetInputConnection(conk->GetOutputPort());
@@ -908,17 +909,17 @@ void vtkSimpleLungMask::FindTracheaTopCoordinates(vtkImageData *in,int initZ, in
 	  continue;
         }
         //Compute volume for that cc
-	cout<<"Tentative Centroid: "<<C[0]<<" "<<C[1]<<" "<<C[2]<<endl;
+	std::cout<<"Tentative Centroid: "<<C[0]<<" "<<C[1]<<" "<<C[2]<<std::endl;
 	//Check cc at centroid location for slice k+sign
 	cckp1 = conkp1->GetOutput()->GetScalarComponentAsFloat(C[0],C[1],C[2],0);
 	if (cckp1 == 0) {
 	  continue;
 	}
         int countkp1=this->CountPixels(conkp1->GetOutput(),cckp1);
-	cout<<"Count for that centroid: "<<countkp1<<endl;
+	std::cout<<"Count for that centroid: "<<countkp1<<std::endl;
 
 	if ((fabs(double(countkp1-countk))/(0.5*(countkp1+countk)) < 0.2) & (countkp1 * sp[0]*sp[1] <= this->TracheaAreaTh) & (countkp1 > 10) ) {
-	  cout<<"Trachea found at "<<k<<endl;
+	  std::cout<<"Trachea found at "<<k<<std::endl;
 	  C[2]=k;
 	  delete [] hist;
           slice1->Delete();
@@ -999,8 +1000,8 @@ void vtkSimpleLungMask::ExtractTrachea(vtkImageData *in) {
         sign = 1;
     }
 
-    //cout<<"Direction: "<<sign<<endl;
-    //cout<<"Init Z: "<<initZ<<" End Z:"<<endZ<<endl;
+    //std::cout<<"Direction: "<<sign<<std::endl;
+    //std::cout<<"Init Z: "<<initZ<<" End Z:"<<endZ<<std::endl;
 
     // Extract slices from initZ: do slice by slice analysis.
     int testext[6];
@@ -1037,7 +1038,7 @@ void vtkSimpleLungMask::ExtractTrachea(vtkImageData *in) {
     this->FindTracheaTopCoordinates(in,initZ,endZ,sign,C);
 
     if (C[0] + C[1] + C[2] == 0) {
-      cout<<"Trachea not found"<<endl;
+      std::cout<<"Trachea not found"<<std::endl;
       slice->Delete();
       return;
     }
@@ -1049,10 +1050,10 @@ void vtkSimpleLungMask::ExtractTrachea(vtkImageData *in) {
         testext[5] = k;
             // Check pixval in seed to see if we have to stop
             // We should be always inside the trachea until we branch off.
-            //cout<<"Check slice #: "<<k<<endl;
+            //std::cout<<"Check slice #: "<<k<<std::endl;
             C[2]=k;
             if (in->GetScalarComponentAsFloat(C[0],C[1],C[2],0) == 0 ) {
-                cout<<"Out of trachea boundaries at "<<k<<endl;
+                std::cout<<"Out of trachea boundaries at "<<k<<std::endl;
                 break;
             }
 
@@ -1079,11 +1080,11 @@ void vtkSimpleLungMask::ExtractTrachea(vtkImageData *in) {
             cc->SetInputConnectValue(this->WholeLungLabel);
             cc->SetOutputConnectedValue(this->WholeLungLabel);
             cc->SetOutputUnconnectedValue(0);
-            //cout<<"Doing CC"<<endl;
+            //std::cout<<"Doing CC"<<std::endl;
             cc->Update();
 	          di_er->Delete();
-            //cout<<"CC done"<<endl;
-            //cout<<"Getting inPtr"<<endl;
+            //std::cout<<"CC done"<<std::endl;
+            //std::cout<<"Getting inPtr"<<std::endl;
             inPtr = (unsigned char *)cc->GetOutput()->GetScalarPointer(0,0,0);
 
 	    //Second stop condition: number of pixel selected as trachea lower than a value
@@ -1097,7 +1098,7 @@ void vtkSimpleLungMask::ExtractTrachea(vtkImageData *in) {
 	    count = (int) (count * sp[0]*sp[1]);
 
 	    if (count > this->TracheaAreaTh) {
-        cout<<"We walk into the lung at "<<k<<endl;
+        std::cout<<"We walk into the lung at "<<k<<std::endl;
         cc->Delete();
         break;
 	    }
@@ -1112,7 +1113,7 @@ void vtkSimpleLungMask::ExtractTrachea(vtkImageData *in) {
       
 	    inPtr = (unsigned char *)di_er2->GetOutput()->GetScalarPointer(0,0,0);
 	    outPtr = (unsigned char *)in->GetScalarPointerForExtent(testext);
-	    //cout<<"Copy process input in output"<<endl;
+	    //std::cout<<"Copy process input in output"<<std::endl;
       for (int i = 0; i< numPoints; i++) {
           if ((short) (*inPtr) == this->WholeLungLabel)
               *outPtr = (unsigned char) (this->UcharTracheaLabel);
@@ -1125,7 +1126,7 @@ void vtkSimpleLungMask::ExtractTrachea(vtkImageData *in) {
 	    testext[4]=0;
 	    testext[5]=0;
       this->ComputeCentroid(di_er2->GetOutput(),testext,C);
-      //cout<<"New seed: "<<C[0]<<" "<<C[1]<<" "<<C[2]<<endl;
+      //std::cout<<"New seed: "<<C[0]<<" "<<C[1]<<" "<<C[2]<<std::endl;
       // Delete Objects
       di_er2->Delete();
 
@@ -1165,8 +1166,8 @@ void vtkSimpleLungMask::ExtractTracheaOLD(vtkImageData *in) {
         sign = 1;
     }
 
-    //cout<<"Direction: "<<sign<<endl;
-    //cout<<"Init Z: "<<initZ<<" End Z:"<<endZ<<endl;
+    //std::cout<<"Direction: "<<sign<<std::endl;
+    //std::cout<<"Init Z: "<<initZ<<" End Z:"<<endZ<<std::endl;
 
     // Extract slices from initZ: do slice by slice analysis.
     int testext[6];
@@ -1207,7 +1208,7 @@ void vtkSimpleLungMask::ExtractTracheaOLD(vtkImageData *in) {
             C[1] = 0;
             C[2] = 0;
             this->ComputeCentroid(in,testext,C);
-            //cout<<"Testing for init trachea: "<<C[0]<<" "<<C[1]<<" "<<C[2]<<endl;
+            //std::cout<<"Testing for init trachea: "<<C[0]<<" "<<C[1]<<" "<<C[2]<<std::endl;
             if (C[0] + C[1] + C[2] == 0) {
                 k = k + sign;
                 continue;
@@ -1216,16 +1217,16 @@ void vtkSimpleLungMask::ExtractTracheaOLD(vtkImageData *in) {
 	      k = k + sign;
 	      continue;
             }
-            cout<<"Trachea found at "<<k<<endl;
+            std::cout<<"Trachea found at "<<k<<std::endl;
             flag = 1;
             k = k-sign;
         } else {
             // Check pixval in seed to see if we have to stop
             // We should be always inside the trachea until we branch off.
-            //cout<<"Check slice #: "<<k<<endl;
+            //std::cout<<"Check slice #: "<<k<<std::endl;
             C[2]=k;
             if (in->GetScalarComponentAsFloat(C[0],C[1],C[2],0) == 0 ) {
-                cout<<"Out of trachea boundaries at "<<k<<endl;
+                std::cout<<"Out of trachea boundaries at "<<k<<std::endl;
                 break;
             }
 
@@ -1252,11 +1253,11 @@ void vtkSimpleLungMask::ExtractTracheaOLD(vtkImageData *in) {
             cc->SetInputConnectValue(this->WholeLungLabel);
             cc->SetOutputConnectedValue(this->WholeLungLabel);
             cc->SetOutputUnconnectedValue(0);
-            //cout<<"Doing CC"<<endl;
+            //std::cout<<"Doing CC"<<std::endl;
             cc->Update();
-            //cout<<"CC done"<<endl;
+            //std::cout<<"CC done"<<std::endl;
             outPtr = (unsigned char *)in->GetScalarPointerForExtent(testext);
-            //cout<<"Getting inPtr"<<endl;
+            //std::cout<<"Getting inPtr"<<std::endl;
             inPtr = (unsigned char *)cc->GetOutput()->GetScalarPointer(0,0,0);
 
 	    //Second stop condition: number of pixel selected as trachea lower than a value
@@ -1270,7 +1271,7 @@ void vtkSimpleLungMask::ExtractTracheaOLD(vtkImageData *in) {
 	    count = (int) (count * sp[0]*sp[1]);
 
 	    if (count > this->TracheaAreaTh) {
-	    	cout<<"We walk into the lung at "<<k<<endl;
+	    	std::cout<<"We walk into the lung at "<<k<<std::endl;
 		break;
 	    }
               // Dilate to compensate for the erosion:
@@ -1281,7 +1282,7 @@ void vtkSimpleLungMask::ExtractTracheaOLD(vtkImageData *in) {
             di_er->Update();
 	    cc->Delete();
 	    inPtr = (unsigned char *)di_er->GetOutput()->GetScalarPointer(0,0,0);
-	    //cout<<"Copy process input in output"<<endl;
+	    //std::cout<<"Copy process input in output"<<std::endl;
             for (int i = 0; i< numPoints; i++) {
                 if ((short) (*inPtr) == this->WholeLungLabel)
                     *outPtr = (unsigned char) (this->UcharTracheaLabel);
@@ -1294,7 +1295,7 @@ void vtkSimpleLungMask::ExtractTracheaOLD(vtkImageData *in) {
 	    testext[4]=0;
 	    testext[5]=0;
             this->ComputeCentroid(di_er->GetOutput(),testext,C);
-            //cout<<"New seed: "<<C[0]<<" "<<C[1]<<" "<<C[2]<<endl;
+            //std::cout<<"New seed: "<<C[0]<<" "<<C[1]<<" "<<C[2]<<std::endl;
             // Delete Objects
             di_er->Delete();
         }
@@ -1335,8 +1336,8 @@ void vtkSimpleLungMask::ExtractUpperTrachea(vtkImageData *outData) {
 
     int k =this->TracheaInitZ;
     int foundTopLung =0;
-    cout<<"Extracing upper trachea"<<endl;
-    cout<<"Init Z: "<<k<<" sign: "<<sign<<endl;
+    std::cout<<"Extracing upper trachea"<<std::endl;
+    std::cout<<"Init Z: "<<k<<" sign: "<<sign<<std::endl;
     do {
     testext[4]=k;
     testext[5]=k;
@@ -1354,7 +1355,7 @@ void vtkSimpleLungMask::ExtractUpperTrachea(vtkImageData *outData) {
         if (this->TracheaLabel == (short) (*outPtr))
           {
           *outPtr = (this->UpperTracheaLabel);
-           //cout<<"Replacing lung label"<<endl;
+           //std::cout<<"Replacing lung label"<<std::endl;
           }
         }
      outPtr++;
@@ -1391,7 +1392,7 @@ void vtkSimpleLungMask::SplitLung(vtkImageData *outData) {
     double svtk[4];
     this->GetRasToVtk()->MultiplyPoint(saxis,svtk);
     int IS; //flag to now if the Volumes in memory is IS or SI
-    //cout<<"S vtk axis: "<<svtk[0]<<" "<<svtk[1]<<" "<<svtk[2]<<endl;
+    //std::cout<<"S vtk axis: "<<svtk[0]<<" "<<svtk[1]<<" "<<svtk[2]<<std::endl;
     if (svtk[2]<0)
         IS =0;
      else

--- a/Common/vtkTubularScalePolyDataFilter.cxx
+++ b/Common/vtkTubularScalePolyDataFilter.cxx
@@ -24,6 +24,7 @@
 #include "vtkPointData.h"
 #include "vtkPolyData.h"
 #include "vtkNRRDExport.h"
+#include <iostream>
 
 vtkStandardNewMacro(vtkTubularScalePolyDataFilter);
 
@@ -80,7 +81,7 @@ int vtkTubularScalePolyDataFilter::RequestData(vtkInformation *request,
   double sp[3], org[3];
   inData->GetSpacing(sp);
   inData->GetOrigin(org);
-  cout<<"org: "<<org[0]<<" "<<org[1]<<" "<<org[2]<<endl;
+  std::cout<<"org: "<<org[0]<<" "<<org[1]<<" "<<org[2]<<std::endl;
   
   vtkPoints *newPts = vtkPoints::New();
   vtkDoubleArray *scaleArray = vtkDoubleArray::New();
@@ -114,7 +115,7 @@ int vtkTubularScalePolyDataFilter::RequestData(vtkInformation *request,
   if (E) {
     //vtkErrorMacro("Error Setting Gage Context... Leaving Execute");
     //Delete local objects
-    cout<<"Error Setting Gage Context... Leaving Execute"<<endl;
+    std::cout<<"Error Setting Gage Context... Leaving Execute"<<std::endl;
     gageContextNix(gtx);
     nrrdexport->Delete();
     return 0;
@@ -142,7 +143,7 @@ int vtkTubularScalePolyDataFilter::RequestData(vtkInformation *request,
   vtkIdType npts = 0;
   vtkIdType *pts = 0;
   inLines->InitTraversal();
-  cout<<" Num cells: :"<<inLines->GetNumberOfCells()<<endl;
+  std::cout<<" Num cells: :"<<inLines->GetNumberOfCells()<<std::endl;
   for (int i = 0; i<inLines->GetNumberOfCells();i++) {
     //Get list point in cell
     inLines->GetNextCell(npts,pts);
@@ -157,10 +158,10 @@ int vtkTubularScalePolyDataFilter::RequestData(vtkInformation *request,
         coord[k]=ijk[k]+pcoords[k];
         coord[k]=(xyzin[k]-org[k])/sp[k];
       }
-      //cout<<"flag: "<<flag<<" pid: "<<pts[j]<<" "<<xyzin[0]<<" "<<xyzin[1]<<" "<<xyzin[2]<<endl;
-      //cout<<"ijk: "<<ijk[0]<<" "<<ijk[1]<<" "<<ijk[2]<<endl;
+      //std::cout<<"flag: "<<flag<<" pid: "<<pts[j]<<" "<<xyzin[0]<<" "<<xyzin[1]<<" "<<xyzin[2]<<std::endl;
+      //std::cout<<"ijk: "<<ijk[0]<<" "<<ijk[1]<<" "<<ijk[2]<<std::endl;
       scale = helper->ScaleSelection(gtx,pvl,coord,initScale,finalScale,scaleStep);
-      //cout<<"coords: "<<coord[0]<<" "<<coord[1]<<" "<<coord[2]<<" Scale: "<<scale<<endl;
+      //std::cout<<"coords: "<<coord[0]<<" "<<coord[1]<<" "<<coord[2]<<" Scale: "<<scale<<std::endl;
 
       scaleArray->SetValue(pts[j],scale);
       }  
@@ -179,7 +180,7 @@ void vtkTubularScalePolyDataFilter::PrintSelf(ostream& os, vtkIndent indent)
 {
   this->Superclass::PrintSelf(os,indent);
 
-  os << indent << "running class: "<<this->GetClassName()<<endl;
+  os << indent << "running class: "<<this->GetClassName()<<std::endl;
 
 }
 

--- a/Common/vtkTubularScaleSelection.cxx
+++ b/Common/vtkTubularScaleSelection.cxx
@@ -32,6 +32,7 @@
 #include "vnl/vnl_math.h"
 #include <math.h>
 #include "vtkNRRDExport.h"
+#include <iostream>
 #define VTK_EPS 1e-12
 
 vtkStandardNewMacro(vtkTubularScaleSelection);
@@ -145,11 +146,11 @@ void vtkTubularScaleSelectionExecute(vtkTubularScaleSelection *self, vtkImageDat
   double scale = initScale;
   int E = 0;
   for (int i=0; i<numScales; i++) {
-    //cout<<"Creating gtx for scale: "<<i<<"thread "<<id<<endl;
+    //std::cout<<"Creating gtx for scale: "<<i<<"thread "<<id<<std::endl;
     //fflush(stdout);
     gtx[i] = gageContextNew();
     if (gtx[i]==NULL) {
-      cout<<"We have a problem creating Context"<<endl;
+      std::cout<<"We have a problem creating Context"<<std::endl;
     }
     gageParmSet(gtx[i], gageParmRenormalize, AIR_TRUE); // slows things down if true
     if (!E) E |= !(pvl[i] = gagePerVolumeNew(gtx[i], nin, gageKindScl));
@@ -157,7 +158,7 @@ void vtkTubularScaleSelectionExecute(vtkTubularScaleSelection *self, vtkImageDat
     if (!E) E |= self->SettingContext(gtx[i],pvl[i],scale);
     scale = scale+scaleStep;
     if (E) {
-     cout<<"Error Setting Context for scale "<<i<<endl;
+     std::cout<<"Error Setting Context for scale "<<i<<std::endl;
      break;
     }
   }
@@ -177,7 +178,7 @@ void vtkTubularScaleSelectionExecute(vtkTubularScaleSelection *self, vtkImageDat
         if (!(count%target))
           {
           self->UpdateProgress(count/(50.0*target));
-          cout<<"Progress Update: "<<count/(50.0*target)<<endl;
+          std::cout<<"Progress Update: "<<count/(50.0*target)<<std::endl;
           }
         count++;
         }
@@ -203,7 +204,7 @@ void vtkTubularScaleSelectionExecute(vtkTubularScaleSelection *self, vtkImageDat
         scale = self->ScaleSelection(gtx,pvl,xyz,initScale,finalScale,scaleStep);
         *outPtr = scale;
         if (scale<1 && scale>=0)
-          cout<<"Something is weird: "<<scale<<endl;
+          std::cout<<"Something is weird: "<<scale<<std::endl;
         outPtr++;
         inPtId++;
        }
@@ -422,7 +423,7 @@ double vtkTubularScaleSelection::ScaleSelection(gageContext *gtx, gagePerVolume 
     if (!E) E |= gageUpdate(gtx);
     //heval = gageAnswerPointer(gtx, pvl, gageSclHessEval);
     gageProbe(gtx,Seed[0],Seed[1],Seed[2]);
-    //cout<<"Testing Scale: "<<S<<"  Eigenvalues: "<<heval[0]<<" "<<heval[1]<<" "<<heval[2]<<"  Mode: "<<this->Mode(heval)<<"  Disparity measure: "<< (heval[0] + heval[1])/2 - fabs(heval[2])<<endl;
+    //std::cout<<"Testing Scale: "<<S<<"  Eigenvalues: "<<heval[0]<<" "<<heval[1]<<" "<<heval[2]<<"  Mode: "<<this->Mode(heval)<<"  Disparity measure: "<< (heval[0] + heval[1])/2 - fabs(heval[2])<<std::endl;
 
     nextV = S*S*featureSign*this->Strength(heval);
     if (nextV > prevV && featureSign*heval[1]> 0 && featureSign*heval[1] > fabs(heval[2])) {

--- a/Utilities/VTK/vtkNRRDReaderCIP.cxx
+++ b/Utilities/VTK/vtkNRRDReaderCIP.cxx
@@ -50,6 +50,7 @@
 
 // Teem includes
 #include "teem/ten.h"
+#include <iostream>
 
 vtkStandardNewMacro(vtkNRRDReaderCIP);
 
@@ -1013,7 +1014,7 @@ void vtkNRRDReaderCIP::ExecuteDataWithInformation(vtkDataObject *output, vtkInfo
 
        const char *key = 0;
        int E;
-       cout<<"Kind: Masked Sym Matrix"<<endl;
+       std::cout<<"Kind: Masked Sym Matrix"<<std::endl;
        // Call tendExpand(nout,nin,scale,threshold)
        // Set up threshold to -1 to avoid this
        Nrrd *ntmp = nrrdNew();


### PR DESCRIPTION
`ChestImagingPlatform` does not build against ITK 6 — 86 errors across 14 files. Five distinct causes. Verified building against **ITK 5.4 and ITK 6.0.0 `main`**.

**Supersedes #4**, which fixed the `<iostream>` half in 4 of the 15 affected files. This covers all of them and takes a different approach in headers — see below. #4 can be closed if this is preferred.

<details>
<summary>1 &mdash; unqualified cout / endl (56 errors)</summary>

ITK 6 no longer transitively drags in `<iostream>` or a `using namespace std`, so bare `cout` and `endl` stopped resolving. Many of the remaining errors were cascades: bare `cout` was resolving to `std::count`, producing

```
invalid operands to binary expression ('unsigned long' and 'const char[18]')
```

which looks unrelated until the root cause is fixed.

`<iostream>` is added and the uses are **qualified with `std::`** rather than adding `using namespace std;`. Two of the affected files — `cipNewtonOptimizer.txx` and `itkCIPMergeChestLabelMapsImageFilter.h` — are headers, where a `using namespace std;` leaks into every consumer.
</details>

<details>
<summary>2 &mdash; vnl_symmetric_eigensystem no longer transitively included</summary>

`GenerateLobeSurfaceModelsHelper.cxx` used `vnl_symmetric_eigensystem` without including it, relying on an ITK header to pull it in. Included directly.
</details>

<details>
<summary>3 &mdash; vnl_matrix_inverse implicit conversion removed</summary>

```
cipNewtonOptimizer.txx:101:13: error: no viable overloaded '='
```

`vnl_matrix_inverse`'s implicit `operator vnl_matrix<T>()` was deprecated in 5.4 and is `explicit`-only in 6, so assigning it to a `vnl_matrix<double>` no longer compiles. `as_matrix()` is used instead — it exists in **both** 5.4 and 6, and is exactly what VNL's own 5.4 deprecation message recommends:

> `USE: .as_matrix() or .as_ref() member function for clarity`
</details>

<details>
<summary>4 &mdash; itkTypeMacro named a class that does not exist</summary>

```cpp
itkTypeMacro(MergeChestLabelMapsImageFilter, ImageToImageFilter);
```

The class is `CIPMergeChestLabelMapsImageFilter`. ITK 6 requires the first argument to name the real type, so this latent error became fatal.
</details>

<details>
<summary>5 &mdash; GradientTolerance was never a member</summary>

`cipNewtonOptimizer`'s verbose output referenced `this->GradientTolerance`; the field is `GradientDifferenceTolerance`. A pre-existing bug, latent because the enclosing template was never instantiated past the earlier errors.
</details>

<details>
<summary>Verification</summary>

Built in a downstream forest testbed that builds Slicer plus the full ExtensionsIndex against a chosen ITK ref, on macOS arm64.

| Configuration | Result |
|---|---|
| ITK 5.4 | compiles clean |
| ITK 6.0.0 `main` (`fee22c1e22`, 2026-08-22) | **0 errors; `libCIPCommon.a` and CommandLineTools binaries produced** |

Verified by artifact rather than by build exit code.

Two things stated plainly:

- With `ITK_FUTURE_LEGACY_REMOVE=ON` the build still fails, on `itkTypeMacro` deprecations in `itkCIPExtractChestLabelMapImageFilter.h` and on `vnl_symmetric_eigensystem.h` itself being deprecated in favour of `itk::bridge::SymmetricEigenDecomposition`. Both are separate pieces of work.
- Three files (`GenerateLobeSurfaceModelsHelper.cxx`, `cipNewtonOptimizer.txx`, `itkCIPMergeChestLabelMapsImageFilter.h`) use CRLF line endings upstream; that has been preserved so the diff stays reviewable.
</details>

<!--
provenance: itk_forest_build_testbed, 2026-08-22, macOS arm64
itk6_ref: fee22c1e22 (6.0.0 main) ; itk5_ref: release-5.4
supersedes: Slicer/ChestImagingPlatform#4 (iostream in 4 of 15 files, via using namespace std)
error_count: 86 -> 0 on ITK 6
future_legacy_remove: fails on pre-existing itkTypeMacro + deprecated vnl_symmetric_eigensystem.h
note: extension-level build still blocked in the testbed by an unrelated Qt6 path collision
-->
